### PR TITLE
ci: fix GitHub Pages deploy workflow for Actions source

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -4,13 +4,17 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pages: write
   id-token: write
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,12 +39,21 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          publish_branch: gh-pages
-          keep_files: false
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Fix GitHub Pages deployment workflow to match repository Pages configuration (`Source: GitHub Actions`).

## Root cause of failed run
Run `21954825514` failed because `peaceiris/actions-gh-pages` attempted to push to `gh-pages` using a token with `contents: read`, causing `403 Permission denied to github-actions[bot]`.

## Changes
- Replace branch-push deploy strategy with official GitHub Pages actions flow:
  - `actions/configure-pages@v5`
  - `actions/upload-pages-artifact@v3`
  - `actions/deploy-pages@v4`
- Keep trigger as requested: `push` to `main`
- Add `concurrency` for Pages deployments

## File changed
- `.github/workflows/pages-deploy.yml`

This aligns with the repo’s Pages settings shown in GitHub UI (Build and deployment source: GitHub Actions).