### PR TITLE
feat: quiz-knowledge integration — category bias + I don't know (#7)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -378,6 +378,7 @@
     .quiz-choice.selected { background: rgba(100,130,200,0.3); color: #fff; }
     .quiz-choice.correct { color: #4caf50; }
     .quiz-choice.wrong { color: #f44336; }
+    .quiz-choice.idk { color: #ce93d8; }
     #quizResult { text-align: center; margin-top: 10px; font-weight: bold; font-size: 16px; }
     #quizHint { color: #ffaa44; font-style: italic; margin-top: 6px; font-size: 12px; }
     #quizNav { color: #aaa; font-size: 12px; margin-top: 8px; }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,10 @@ import { preloadEmojiSprites } from './emoji-cache';
 import { initMinimap, renderMinimap } from './minimap';
 import {
   createKnowledgeState, toggleBook, syncBookUI, wireBookUI, showSubjectSelection,
+  getQuizBias, openArticle,
   type KnowledgeState,
 } from './knowledge';
+import { searchArticles } from './config/knowledge.config';
 
 
 // ─── Game State ──────────────────────────────────────────────
@@ -355,10 +357,29 @@ function update(state: GameState, input: InputManager): void {
           for (const r of rewards) state.inventory.addItem(r.itemId, r.qty);
           addToast(state.ui, `Quiz reward! +${rewards.map((r) => `${r.qty} ${r.itemId}`).join(', ')}`, '#4caf50');
           state.quizStats.correct++;
+        } else if (state.quiz.result === 'idk') {
+          // "I don't know" → open Book to related article
+          const category = state.quiz.question?.category || '';
+          const questionText = state.quiz.question?.question || '';
+          // Search for articles related to the quiz category or question
+          const related = searchArticles(category) || searchArticles(questionText);
+          if (related.length > 0) {
+            openArticle(state.knowledge, related[0].id);
+            state.knowledge.bookOpen = true;
+            state.knowledge.activeTab = 'browse';
+            addToast(state.ui, '📖 Check the Book of Knowledge for help!', '#ce93d8', 3000);
+          } else {
+            state.knowledge.bookOpen = true;
+            state.knowledge.activeTab = 'browse';
+            addToast(state.ui, '📖 Browse articles for clues!', '#ce93d8', 3000);
+          }
+          // Don't count "I don't know" as answered
         }
-        state.quizStats.answered++;
+        if (state.quiz.result !== 'idk') {
+          state.quizStats.answered++;
+        }
         quizClose(state.quiz);
-        state.paused = false;
+        state.paused = state.knowledge.bookOpen;
       } else {
         quizSubmit(state.quiz);
       }
@@ -509,10 +530,10 @@ function handleInteraction(result: InteractionResult, state: GameState): void {
       // If NPC can quiz, start quiz after dialog
       if (persona?.canQuiz) {
         // Quiz starts on dialog close (handled in update loop)
-        // For now, store pending quiz
+        const bias = getQuizBias(state.knowledge);
         setTimeout(() => {
           if (!state.quiz.active) {
-            startQuiz(state.quiz, persona.quizDifficulty, result.npcId);
+            startQuiz(state.quiz, persona.quizDifficulty, result.npcId, bias);
             state.paused = true;
           }
         }, 100);

--- a/src/quiz.ts
+++ b/src/quiz.ts
@@ -15,10 +15,10 @@ export interface QuizState {
   active: boolean;
   question: QuizQuestion | null;
   displayText: string;      // Possibly LLM-rephrased
-  choices: string[];         // Shuffled answer options
+  choices: string[];         // Shuffled answer options (last is always "I don't know")
   correctIndex: number;      // Index of correct answer in shuffled choices
   selectedIndex: number;     // Player's current selection (-1 = none)
-  result: 'pending' | 'correct' | 'wrong';
+  result: 'pending' | 'correct' | 'wrong' | 'idk';
   npcId: string | null;      // NPC that triggered the quiz
   difficulty: QuizDifficulty;
 }
@@ -41,12 +41,14 @@ export function createQuizState(): QuizState {
 
 /**
  * Start a quiz for the given difficulty.
- * Picks a random question, shuffles choices, optionally rephrases.
+ * Picks a random question (biased by category weights), shuffles choices, optionally rephrases.
+ * @param categoryBias - optional Record<category, weight> for weighted random selection
  */
 export async function startQuiz(
   state: QuizState,
   difficulty: QuizDifficulty,
   npcId: string | null,
+  categoryBias?: Record<string, number>,
 ): Promise<void> {
   // Filter eligible questions
   const eligible = getQuestions(undefined, difficulty);
@@ -56,13 +58,28 @@ export async function startQuiz(
     return;
   }
 
-  const question = eligible[Math.floor(Math.random() * eligible.length)];
+  // Apply category bias: duplicate entries for biased categories
+  let pool: QuizQuestion[];
+  if (categoryBias && Object.keys(categoryBias).length > 0) {
+    pool = [];
+    for (const q of eligible) {
+      const weight = categoryBias[q.category] || 1;
+      for (let i = 0; i < weight; i++) pool.push(q);
+    }
+  } else {
+    pool = eligible;
+  }
+
+  const question = pool[Math.floor(Math.random() * pool.length)];
 
   // Shuffle the answers array (correct answer is always at index 0 in source)
   const shuffledAnswers = [...question.answers];
   shuffle(shuffledAnswers);
   const correctAnswer = question.answers[0]; // Original correct answer
   const correctIdx = shuffledAnswers.indexOf(correctAnswer);
+
+  // Add "I don't know" as the last option
+  shuffledAnswers.push("I don't know 📖");
 
   // Try LLM rephrase (fallback: original text)
   const displayText = await rephraseQuizQuestion(question.question);
@@ -89,17 +106,23 @@ export function quizNavigate(state: QuizState, delta: number): void {
 
 /**
  * Submit the current selection.
- * Returns true if correct.
+ * Returns 'correct', 'wrong', or 'idk'.
  */
-export function quizSubmit(state: QuizState): boolean {
-  if (!state.active || state.result !== 'pending') return false;
+export function quizSubmit(state: QuizState): 'correct' | 'wrong' | 'idk' {
+  if (!state.active || state.result !== 'pending') return 'wrong';
+
+  // "I don't know" is always the last choice
+  if (state.selectedIndex === state.choices.length - 1) {
+    state.result = 'idk';
+    return 'idk';
+  }
 
   if (state.selectedIndex === state.correctIndex) {
     state.result = 'correct';
-    return true;
+    return 'correct';
   } else {
     state.result = 'wrong';
-    return false;
+    return 'wrong';
   }
 }
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -177,15 +177,19 @@ function syncQuiz(quiz: QuizState): void {
       div.className = 'quiz-choice';
       const selected = i === quiz.selectedIndex;
       const isCorrect = i === quiz.correctIndex;
+      const isIdkOption = i === quiz.choices.length - 1; // Last option is "I don't know"
 
       if (selected) div.classList.add('selected');
       if (quiz.result !== 'pending') {
         if (isCorrect) div.classList.add('correct');
         else if (selected && quiz.result === 'wrong') div.classList.add('wrong');
+        else if (selected && quiz.result === 'idk') div.classList.add('idk');
       }
 
       const marker = selected ? '▸ ' : '  ';
-      div.textContent = `${marker}${String.fromCharCode(65 + i)}) ${choice}`;
+      // Don't use letter label for "I don't know"
+      const label = isIdkOption ? `${marker}${choice}` : `${marker}${String.fromCharCode(65 + i)}) ${choice}`;
+      div.textContent = label;
       choicesEl.appendChild(div);
     });
   }
@@ -196,6 +200,9 @@ function syncQuiz(quiz: QuizState): void {
     } else if (quiz.result === 'correct') {
       resultEl.textContent = '✅ Correct!';
       resultEl.style.color = '#4caf50';
+    } else if (quiz.result === 'idk') {
+      resultEl.textContent = '📖 Opening Book of Knowledge...';
+      resultEl.style.color = '#ce93d8';
     } else {
       resultEl.textContent = '❌ Wrong!';
       resultEl.style.color = '#f44336';
@@ -209,7 +216,7 @@ function syncQuiz(quiz: QuizState): void {
 
   if (navEl) {
     navEl.textContent = quiz.result !== 'pending'
-      ? 'Space to continue'
+      ? (quiz.result === 'idk' ? 'Space to open Book' : 'Space to continue')
       : '↑↓ Navigate • Space to select';
   }
 }


### PR DESCRIPTION
## 🧠 Quiz-Knowledge Integration (#7)

### Summary
Connects the Quiz system with the Book of Knowledge: quiz questions are now biased toward the player's selected subjects, and a new "I don't know 📖" option sends players to read related articles instead of penalizing them.

### Changes
- **src/quiz.ts**: Added categoryBias param to startQuiz() for weighted question selection; added "I don't know 📖" as the last quiz choice; quizSubmit() now returns 'idk' result type
- **src/main.ts**: Passes getQuizBias() from knowledge state to quiz start; handles 'idk' result by opening Book to related article; "I don't know" doesn't count toward quiz stats
- **src/ui.ts**: Renders 'idk' result with purple "📖 Opening Book of Knowledge..." text; "Space to open Book" nav hint; purple highlight for selected IDK option
- **src/index.html**: Added .quiz-choice.idk CSS class (purple)

### Educational Flow
1. NPC asks a quiz question
2. Player sees 4 answer choices + "I don't know 📖"
3. If "I don't know" is selected:
   - Quiz category is used to search for related Book articles
   - Book opens directly to a relevant article
   - Player learns the material instead of being penalized
   - Question is NOT counted as answered (no accuracy hit)
4. After reading, player can close the Book and try again later

### Testing
- 33/33 E2E tests pass (1 sporadic NPC timing flake on re-run)
- TypeScript compiles clean
- Visually verified via Playwright MCP: quiz with "I don't know" option, navigation, submission, Book article opening
